### PR TITLE
adds cancel method so jobs can be removed from the scheduler queue

### DIFF
--- a/rq_scheduler/scheduler.py
+++ b/rq_scheduler/scheduler.py
@@ -110,6 +110,12 @@ class Scheduler(object):
                              int((datetime.now() + time_delta).strftime('%s')))
         return job
 
+    def cancel(self, job):
+        """
+        Pulls a job from the scheduler queue
+        """
+        self.connection.zrem(self.scheduled_jobs_key, job.id)
+
     def get_jobs_to_queue(self):
         """
         Returns a list of job instances that should be queued


### PR DESCRIPTION
I'm using this to allow user-defined schedules to be updated.  When an update occurs, the old job in the scheduler queue is canceled and the new one is added in.

In another implementation, I was storing and updating the "most up-to-date job ID" and then, when a job began executing, it would see if its own ID matched the stored one.  If not, the job was obsolete and was aborted.  This worked for celery via the `request context`, but in rq there is no way to find the id within a job's function (https://github.com/nvie/rq/issues/46).
