### PR TITLE
Rename enqueue() to schedule()

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -80,12 +80,12 @@ Periodic & Repeated Jobs
 ------------------------
 
 As of version 0.3, `RQ Scheduler`_ also supports creating periodic and repeated jobs.
-You can do this via the ``enqueue`` method. Note that this feature needs
+You can do this via the ``schedule`` method. Note that this feature needs
 `RQ`_ >= 0.3.1.
 
 This is how you do it::
 
-    scheduler.enqueue(
+    scheduler.schedule(
         scheduled_time=datetime.now(), # Time for first execution
         func=func,                     # Function to be queued
         args=[arg1, arg2],             # Arguments passed into function when executed

--- a/rq_scheduler/scheduler.py
+++ b/rq_scheduler/scheduler.py
@@ -1,6 +1,7 @@
 import signal
 import time
 from datetime import datetime
+import warnings
 
 try:
     from logbook import Logger
@@ -105,9 +106,6 @@ class Scheduler(object):
                              int(scheduled_time.strftime('%s')))
         return job
 
-    # This is here for backwards compatibility purposes
-    schedule = enqueue_at
-
     def enqueue_in(self, time_delta, func, *args, **kwargs):
         """
         Similar to ``enqueue_at``, but accepts a timedelta instead of datetime object.
@@ -124,10 +122,10 @@ class Scheduler(object):
         """
         Schedule a job to be periodically executed, at a certain interval.
         """
-        return self.enqueue(scheduled_time, func, args=args, kwargs=kwargs,
+        return self.schedule(scheduled_time, func, args=args, kwargs=kwargs,
                             interval=interval, repeat=repeat)
 
-    def enqueue(self, scheduled_time, func, args=None, kwargs=None,
+    def schedule(self, scheduled_time, func, args=None, kwargs=None,
                 interval=None, repeat=None, result_ttl=None):
         """
         Schedule a job to be periodically executed, at a certain interval.
@@ -147,6 +145,17 @@ class Scheduler(object):
         self.connection.zadd(self.scheduled_jobs_key, job.id,
                              int(scheduled_time.strftime('%s')))
         return job
+
+    def enqueue(self, scheduled_time, func, args=None, kwargs=None,
+                interval=None, repeat=None, result_ttl=None):
+        """
+        This method is deprecated and only left in as a backwards compatibility
+        alias for schedule().
+        """
+        warnings.warn("'enqueue()' has been deprecated in favor of '.schedule()'"
+                      "and will be removed in a future release.", DeprecationWarning)
+        return self.schedule(scheduled_time, func, args, kwargs, interval,
+                             repeat, result_ttl)
 
     def cancel(self, job):
         """


### PR DESCRIPTION
As discussed in the other ticket, renaming .enqueue() to .schedule() with backwards compatibility.

It seems there already had been a schedule() method at one point. There was an alias to enqueue_at() in the code. I'v simply removed that now. How do you feel about that?
