### PR TITLE
Add a --url parameter to rqscheduler

### DIFF
--- a/rq_scheduler/scripts/rqscheduler.py
+++ b/rq_scheduler/scripts/rqscheduler.py
@@ -12,11 +12,17 @@ def main():
     parser.add_argument('-p', '--port', default=6379, type=int, help="Redis port number")
     parser.add_argument('-d', '--db', default=0, type=int, help="Redis database")
     parser.add_argument('-P', '--password', default=None, help="Redis password")
+    parser.add_argument('--url', '-u', default=None
+        , help='URL describing Redis connection details. \
+            Overrides other connection arguments if supplied.')
     parser.add_argument('-i', '--interval', default=60, type=int
         , help="How often the scheduler checks for new jobs to add to the \
             queue (in seconds).")
     args = parser.parse_args()
-    connection = Redis(args.host, args.port, args.db, args.password)
+    if args.url is not None:
+        connection = Redis.from_url(args.url)
+    else:
+        connection = Redis(args.host, args.port, args.db, args.password)
     scheduler = Scheduler(connection=connection, interval=args.interval)
     scheduler.run()
 


### PR DESCRIPTION
This matches the --url parameter that can be passed into rqworker. Makes usage on Heroku much easier.
