### PR TITLE
Lazily import resolve_connection to allow safe patching

### DIFF
--- a/rq_scheduler/scheduler.py
+++ b/rq_scheduler/scheduler.py
@@ -6,7 +6,6 @@ import warnings
 from datetime import datetime, timedelta
 from itertools import repeat
 
-from rq.connections import resolve_connection
 from rq.exceptions import NoSuchJobError
 from rq.job import Job
 from rq.queue import Queue
@@ -22,6 +21,7 @@ class Scheduler(object):
     scheduled_jobs_key = 'rq:scheduler:scheduled_jobs'
 
     def __init__(self, queue_name='default', interval=60, connection=None):
+        from rq.connections import resolve_connection
         self.connection = resolve_connection(connection)
         self.queue_name = queue_name
         self._interval = interval


### PR DESCRIPTION
Thanks for the great library!

I'm unit testing a subclass of Scheduler and want to test how my overridden method interacts with the superclass. I need an instance of the class which does not interact with Redis, and I think the best way is to patch resolve_connection. (resolve_connection will complain if you pass it an object which is not a Redis object).

Without this change, the patch worked if I ran the test in isolation. But if I ran any tests which imported this file first, the import would already have happened and the patch wouldn't take effect.
