### PR TITLE
add support for --pid argument to create pidfile

### DIFF
--- a/rq_scheduler/scripts/rqscheduler.py
+++ b/rq_scheduler/scripts/rqscheduler.py
@@ -2,6 +2,7 @@
 
 import argparse
 import sys
+import os
 
 from redis import Redis
 from rq_scheduler.scheduler import Scheduler
@@ -20,9 +21,15 @@ def main():
         , help="How often the scheduler checks for new jobs to add to the \
             queue (in seconds).")
     parser.add_argument('--path', default='.', help='Specify the import path.')
+    parser.add_argument('--pid', help='A filename to use for the PID file.', metavar='FILE')
     args = parser.parse_args()
     if args.path:
         sys.path = args.path.split(':') + sys.path
+    if args.pid:
+        pid = str(os.getpid())
+        filename = args.pid
+        with open(filename, 'w') as f:
+            f.write(pid)
     if args.url is not None:
         connection = Redis.from_url(args.url)
     else:


### PR DESCRIPTION
Was looking to monitor rqscheduler via Monit and needed a pid file so it could locate and check the process.

Could be made better by deleting the file in Scheduler.register_death(), but would require passing pidfile parameters to the Scheduler class, which doesn't seem correct.

For Monit, monitoring still works if the pidfile remains after death.
