### PR TITLE
utc and time parsing and formatting support

### DIFF
--- a/rq_scheduler/utils.py
+++ b/rq_scheduler/utils.py
@@ -1,0 +1,13 @@
+import calendar
+from datetime import datetime
+
+# from_unix from times.from_unix()
+def from_unix(string):
+    """Convert a unix timestamp into a utc datetime"""
+    return datetime.utcfromtimestamp(float(string))
+
+
+# to_unix from times.to_unix()
+def to_unix(dt):
+    """Converts a datetime object to unixtime"""
+    return calendar.timegm(dt.utctimetuple())

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -10,7 +10,7 @@ from rq.compat import as_text
 from rq.job import Job
 import warnings
 from rq_scheduler import Scheduler
-from rq_scheduler.scheduler import utcnow, utcformat, to_unix
+from rq_scheduler.utils import to_unix
 
 from tests import RQTestCase
 
@@ -72,7 +72,7 @@ class TestScheduler(RQTestCase):
         """
         Ensure that scheduled jobs are put in the scheduler queue with the right score
         """
-        scheduled_time = utcnow()
+        scheduled_time = datetime.utcnow()
         job = self.scheduler.enqueue_at(scheduled_time, say_hello)
         self.assertEqual(job, Job.fetch(job.id, connection=self.testconn))
         self.assertIn(job.id,
@@ -84,7 +84,7 @@ class TestScheduler(RQTestCase):
         """
         Ensure that jobs have the right scheduled time.
         """
-        right_now = utcnow()
+        right_now = datetime.utcnow()
         time_delta = timedelta(minutes=1)
         job = self.scheduler.enqueue_in(time_delta, say_hello)
         self.assertIn(job.id,
@@ -100,7 +100,7 @@ class TestScheduler(RQTestCase):
         """
         Ensure get_jobs() returns all jobs until the specified time.
         """
-        now = utcnow()
+        now = datetime.utcnow()
         job = self.scheduler.enqueue_at(now, say_hello)
         self.assertIn(job, self.scheduler.get_jobs(now))
         future_time = now + timedelta(hours=1)
@@ -114,7 +114,7 @@ class TestScheduler(RQTestCase):
         """
         Ensure that jobs scheduled the future are not queued.
         """
-        now = utcnow()
+        now = datetime.utcnow()
         job = self.scheduler.enqueue_at(now, say_hello)
         self.assertIn(job, self.scheduler.get_jobs_to_queue())
         future_time = now + timedelta(hours=1)
@@ -128,7 +128,7 @@ class TestScheduler(RQTestCase):
         - "enqueued_at" attribute is properly set
         - Job appears in the right queue
         """
-        now = utcnow()
+        now = datetime.utcnow()
         queue_name = 'foo'
         scheduler = Scheduler(connection=self.testconn, queue_name=queue_name)
 
@@ -143,7 +143,7 @@ class TestScheduler(RQTestCase):
         self.assertIn(job, queue.jobs)
 
     def test_job_membership(self):
-        now = utcnow()
+        now = datetime.utcnow()
         job = self.scheduler.enqueue_at(now, say_hello)
         self.assertIn(job, self.scheduler)
         self.assertIn(job.id, self.scheduler)
@@ -166,7 +166,7 @@ class TestScheduler(RQTestCase):
         """
         Ensure ``change_execution_time`` is called, ensure that job's score is updated
         """
-        job = self.scheduler.enqueue_at(utcnow(), say_hello)
+        job = self.scheduler.enqueue_at(datetime.utcnow(), say_hello)
         new_date = datetime(2010, 1, 1)
         self.scheduler.change_execution_time(job, new_date)
         self.assertEqual(to_unix(new_date),
@@ -178,11 +178,11 @@ class TestScheduler(RQTestCase):
         """
         Ensure that arguments and keyword arguments are properly saved to jobs.
         """
-        job = self.scheduler.enqueue_at(utcnow(), simple_addition, 1, 1, 1)
+        job = self.scheduler.enqueue_at(datetime.utcnow(), simple_addition, 1, 1, 1)
         self.assertEqual(job.args, (1, 1, 1))
-        job = self.scheduler.enqueue_at(utcnow(), simple_addition, z=1, y=1, x=1)
+        job = self.scheduler.enqueue_at(datetime.utcnow(), simple_addition, z=1, y=1, x=1)
         self.assertEqual(job.kwargs, {'x': 1, 'y': 1, 'z': 1})
-        job = self.scheduler.enqueue_at(utcnow(), simple_addition, 1, z=1, y=1)
+        job = self.scheduler.enqueue_at(datetime.utcnow(), simple_addition, 1, z=1, y=1)
         self.assertEqual(job.kwargs, {'y': 1, 'z': 1})
         self.assertEqual(job.args, (1,))
 
@@ -202,7 +202,7 @@ class TestScheduler(RQTestCase):
         with warnings.catch_warnings(record=True) as w:
             # Enable all warnings
             warnings.simplefilter("always")
-            job = self.scheduler.enqueue(utcnow(), say_hello)
+            job = self.scheduler.enqueue(datetime.utcnow(), say_hello)
             self.assertEqual(1, len(w))
             self.assertEqual(w[0].category, DeprecationWarning)
 
@@ -213,7 +213,7 @@ class TestScheduler(RQTestCase):
         with warnings.catch_warnings(record=True) as w:
             # Enable all warnings
             warnings.simplefilter("always")
-            job = self.scheduler.enqueue_periodic(utcnow(), 1, None, say_hello)
+            job = self.scheduler.enqueue_periodic(datetime.utcnow(), 1, None, say_hello)
             self.assertEqual(1, len(w))
             self.assertEqual(w[0].category, DeprecationWarning)
 
@@ -221,7 +221,7 @@ class TestScheduler(RQTestCase):
         """
         Ensure that interval and repeat attributes get correctly saved in Redis.
         """
-        job = self.scheduler.schedule(utcnow(), say_hello, interval=10, repeat=11)
+        job = self.scheduler.schedule(datetime.utcnow(), say_hello, interval=10, repeat=11)
         job_from_queue = Job.fetch(job.id, connection=self.testconn)
         self.assertEqual(job_from_queue.meta['interval'], 10)
         self.assertEqual(job_from_queue.meta['repeat'], 11)
@@ -229,14 +229,14 @@ class TestScheduler(RQTestCase):
     def test_repeat_without_interval_raises_error(self):
         # Ensure that an error is raised if repeat is specified without interval
         def create_job():
-            self.scheduler.schedule(utcnow(), say_hello, repeat=11)
+            self.scheduler.schedule(datetime.utcnow(), say_hello, repeat=11)
         self.assertRaises(ValueError, create_job)
 
     def test_job_with_intervals_get_rescheduled(self):
         """
         Ensure jobs with interval attribute are put back in the scheduler
         """
-        time_now = utcnow()
+        time_now = datetime.utcnow()
         interval = 10
         job = self.scheduler.schedule(time_now, say_hello, interval=interval)
         self.scheduler.enqueue_job(job)
@@ -258,7 +258,7 @@ class TestScheduler(RQTestCase):
         Ensure jobs with repeat attribute are put back in the scheduler
         X (repeat) number of times
         """
-        time_now = utcnow()
+        time_now = datetime.utcnow()
         interval = 10
         # If job is repeated once, the job shouldn't be put back in the queue
         job = self.scheduler.schedule(time_now, say_hello, interval=interval, repeat=1)
@@ -275,7 +275,7 @@ class TestScheduler(RQTestCase):
         self.assertNotIn(job.id,
             tl(self.testconn.zrange(self.scheduler.scheduled_jobs_key, 0, 1)))
 
-        time_now = utcnow()
+        time_now = datetime.utcnow()
         # Now the same thing using enqueue_periodic
         job = self.scheduler.enqueue_periodic(time_now, interval, 1, say_hello)
         self.scheduler.enqueue_job(job)
@@ -295,7 +295,7 @@ class TestScheduler(RQTestCase):
         """
         Ensure jobs that don't exist when queued are removed from the scheduler.
         """
-        job = self.scheduler.schedule(utcnow(), say_hello)
+        job = self.scheduler.schedule(datetime.utcnow(), say_hello)
         job.cancel()
         self.scheduler.get_jobs_to_queue()
         self.assertNotIn(job.id, tl(self.testconn.zrange(
@@ -305,7 +305,7 @@ class TestScheduler(RQTestCase):
         """
         Ensure periodic jobs set result_ttl to infinite.
         """
-        job = self.scheduler.schedule(utcnow(), say_hello, interval=5)
+        job = self.scheduler.schedule(datetime.utcnow(), say_hello, interval=5)
         job_from_queue = Job.fetch(job.id, connection=self.testconn)
         self.assertEqual(job.result_ttl, -1)
 


### PR DESCRIPTION
Builds on #35 and #30 to add UTC support.

Updated utc-time branch to include current state of master branch.
Removed dependency on times library by adding utcnow, utcformat, from_unix, and to_unix functions, which are cribbed partially from the times library and partially from rq.utils.

RQ actually replaced `times.to_universal()` with [utcparse()](https://github.com/nvie/rq/commit/888d771d4d266e964a4623a432539b8c7a742c66#diff-b460bf5f8f26e7bd8f4cb42060d3d5fdR182), a function that only parses string formatted times. The original `times.to_universal()` can also parse Unix timestamps. That is actually what rq-scheduler was using it for. So, I grabbed that part of the original `to_universal()` function and called it `from_unix()` here.

Seems like the tests passed once I discovered that problem.
