### PR TITLE
Don't reuse existing job when spawning a scheduled job

### DIFF
--- a/rq_scheduler/scheduler.py
+++ b/rq_scheduler/scheduler.py
@@ -276,7 +276,7 @@ class Scheduler(object):
         job.save()
 
         queue = self.get_queue_for_job(job)
-        queue.push_job_id(job.id)
+        queue.enqueue_call(job.func, job.args, job.kwargs, job.timeout, job.result_ttl)
         self.connection.zrem(self.scheduled_jobs_key, job.id)
 
         if interval:


### PR DESCRIPTION
Since any job with non-inifinte result_ttl will be eventually cleaned up by RQ, it makes it impossible to use periodic jobs with finite or zero ttl. This change changes saved job into a template to store args, timeout and ttl, but actual executed job will be different so that the template will not be affected.

Fixes #42 
