### PR TITLE
adding enqueue_now with tests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,6 +54,11 @@ There are two ways you can schedule a job. The first is using RQ Scheduler's ``e
     scheduler.enqueue_at(datetime(2020, 1, 1, 3, 4), func, foo, bar=baz)
 
 
+If you want the job to run immediately, you can use ``enqueue_now``::
+
+    scheduler.enqueue_now(func, foo, bar=baz)
+
+
 The second way is using ``enqueue_in``. Instead of taking a ``datetime`` object,
 this method expects a ``timedelta`` and schedules the job to run at
 X seconds/minutes/hours/days/weeks later. For example, if we want to monitor how

--- a/rq_scheduler/scheduler.py
+++ b/rq_scheduler/scheduler.py
@@ -110,6 +110,17 @@ class Scheduler(object):
                               job.id)
         return job
 
+    def enqueue_now(self, func, *args, **kwargs):
+        """
+        Schedules a job to run immediately
+        """
+        now = datetime.utcnow()
+        job = self._create_job(func, args=args, kwargs=kwargs)
+        self.connection._zadd(self.scheduled_jobs_key,
+                              to_unix(now),
+                              job.id)
+        return job
+
     def enqueue_in(self, time_delta, func, *args, **kwargs):
         """
         Similar to ``enqueue_at``, but accepts a timedelta instead of datetime object.


### PR DESCRIPTION
@selwin -- adding enqueue_now method

helps me make a drop in replacement for rq -- also  think its a useful feature in general

added tests and docs
