### PR TITLE
Allow job creation with func as string references.

### DIFF
--- a/rq_scheduler/scheduler.py
+++ b/rq_scheduler/scheduler.py
@@ -72,10 +72,6 @@ class Scheduler(object):
         """
         Creates an RQ job and saves it to Redis.
         """
-        if func.__module__ == '__main__':
-            raise ValueError(
-                    'Functions from the __main__ module cannot be processed '
-                    'by workers.')
         if args is None:
             args = ()
         if kwargs is None:


### PR DESCRIPTION
As rq-scheduler just passes the Job creation off to the rq library and
it accepts functions as string references, we remove the check for
`__main__`.

See Issue #54.

I'd also be happy changing this PR to be something more like `if hasattr(func, '__module__') and if func.__module__....` instead of removing the check altogether.  Whichever you'd prefer!  Thanks again for your consideration!
