### PR TITLE
Add ability to pass Queue objects to scheduler

### DIFF
--- a/rq_scheduler/scheduler.py
+++ b/rq_scheduler/scheduler.py
@@ -20,10 +20,14 @@ class Scheduler(object):
     scheduler_key = 'rq:scheduler'
     scheduled_jobs_key = 'rq:scheduler:scheduled_jobs'
 
-    def __init__(self, queue_name='default', interval=60, connection=None):
+    def __init__(self, queue_name='default', queue=None, interval=60, connection=None):
         from rq.connections import resolve_connection
         self.connection = resolve_connection(connection)
-        self.queue_name = queue_name
+        self._queue = queue
+        if self._queue is None:
+            self.queue_name = queue_name
+        else:
+            self.queue_name = self._queue.name
         self._interval = interval
         self.log = logger
         self._lock_acquired = False
@@ -107,7 +111,10 @@ class Scheduler(object):
         job = Job.create(func, args=args, connection=self.connection,
                          kwargs=kwargs, result_ttl=result_ttl, ttl=ttl, id=id,
                          description=description, timeout=timeout)
-        job.origin = queue_name or self.queue_name
+        if self._queue is not None:
+            job.origin = self._queue.name
+        else:
+            job.origin = queue_name or self.queue_name
         if commit:
             job.save()
         return job
@@ -304,6 +311,8 @@ class Scheduler(object):
         """
         Returns a queue to put job into.
         """
+        if self._queue is not None:
+            return self._queue
         key = '{0}{1}'.format(Queue.redis_queue_namespace_prefix, job.origin)
         return Queue.from_queue_key(key, connection=self.connection)
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -272,6 +272,21 @@ class TestScheduler(RQTestCase):
         self.assertIn(job, queue.jobs)
         self.assertIn(queue, Queue.all())
 
+    def test_enqueue_job_with_queue(self):
+        """
+        Ensure that job is enqueued correctly when the scheduler is bound
+        to a queue object.
+        """
+        queue = Queue('foo', connection=self.testconn)
+        scheduler = Scheduler(connection=self.testconn, queue=queue)
+        job = scheduler._create_job(say_hello)
+        scheduler_queue = scheduler.get_queue_for_job(job)
+        self.assertEqual(queue, scheduler_queue)
+        scheduler.enqueue_job(job)
+        self.assertTrue(job.enqueued_at is not None)
+        self.assertIn(job, queue.jobs)
+        self.assertIn(queue, Queue.all())
+
     def test_job_membership(self):
         now = datetime.utcnow()
         job = self.scheduler.enqueue_at(now, say_hello)


### PR DESCRIPTION
Currently the scheduler looks for the queue with `Queue.queue_from_key()`, which can be inadequate in cases where we want a Queue object with properties that are not saved in Redis (for example, `async=False`). This change makes it possible to bind the scheduler to a specific queue, instead of looking for it by name and creating the object.