### PR TITLE
support custom job/queue classes, update rq dependency accordingly

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -210,6 +210,8 @@ The script accepts these arguments:
 * ``-P`` or ``--password``: password to connect to Redis
 * ``-b`` or ``--burst``: runs in burst mode (enqueue scheduled jobs whose execution time is in the past and quit)
 * ``-i INTERVAL`` or ``--interval INTERVAL``: How often the scheduler checks for new jobs to add to the queue (in seconds, can be floating-point for more precision).
+* ``-j`` or ``--job-class``: specify custom job class for rq to use (python module.Class)
+* ``-q`` or ``--queue-class``: specify custom queue class for rq to use (python module.Class)
 
 The arguments pull default values from environment variables with the
 same names but with a prefix of ``RQ_REDIS_``.

--- a/rq_scheduler/scripts/rqscheduler.py
+++ b/rq_scheduler/scripts/rqscheduler.py
@@ -27,6 +27,8 @@ def main():
             queue (in seconds, can be floating-point for more precision).")
     parser.add_argument('--path', default='.', help='Specify the import path.')
     parser.add_argument('--pid', help='A filename to use for the PID file.', metavar='FILE')
+    parser.add_argument('-j', '--job-class', help='Custom RQ Job class')
+    parser.add_argument('-q', '--queue-class', help='Custom RQ Queue class')
 
     args = parser.parse_args()
 
@@ -52,7 +54,10 @@ def main():
         level = 'INFO'
     setup_loghandlers(level)
 
-    scheduler = Scheduler(connection=connection, interval=args.interval)
+    scheduler = Scheduler(connection=connection,
+                          interval=args.interval,
+                          job_class=args.job_class,
+                          queue_class=args.queue_class)
     scheduler.run(burst=args.burst)
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     ''',
     package_data={'': ['README.rst']},
     tests_require=tests_require,
-    install_requires=['rq>=0.6.0', 'croniter>=0.3.9'] + tests_require,
+    install_requires=['rq>=0.8.0', 'croniter>=0.3.9'] + tests_require,
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Console',

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,22 @@
 # -*- coding: utf-8 -*-
+import sys
+
 from setuptools import setup
-import platform
 
 tests_require = []
-if platform.python_version() < '2.7':
+if sys.version_info < (2, 7):
     tests_require.append('discover==0.4.0')
+
+def get_dependencies():
+    deps = [
+        'croniter>=0.3.9',
+    ]
+    if (sys.version_info < (2, 7) or
+            (sys.version_info >= (3, 0) and sys.version_info < (3, 1))):
+        deps += ['rq~=0.8.0']
+    else:
+        deps += ['rq>=0.8.0']
+    return deps
 
 setup(
     name='rq-scheduler',
@@ -24,7 +36,7 @@ setup(
     ''',
     package_data={'': ['README.rst']},
     tests_require=tests_require,
-    install_requires=['rq>=0.8.0', 'croniter>=0.3.9'] + tests_require,
+    install_requires=get_dependencies() + tests_require,
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Console',


### PR DESCRIPTION
This enables custom job/queue classes to be used in scheduler the same way as it is possible in rq (since 0.8). No additional code paths, just changing Job/Queue to swappable attributes, therefore tests should cover this as is.