### PR TITLE
Add meta parameter for Job instances

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -97,7 +97,8 @@ This is how you do it
         args=[arg1, arg2],             # Arguments passed into function when executed
         kwargs={'foo': 'bar'},         # Keyword arguments passed into function when executed
         interval=60,                   # Time before the function is called again, in seconds
-        repeat=10                      # Repeat this number of times (None means repeat forever)
+        repeat=10,                     # Repeat this number of times (None means repeat forever)
+        meta={'foo': 'bar'}            # Arbitrary pickleable data on the job itself
     )
 
 **IMPORTANT NOTE**: If you set up a repeated job, you must make sure that you
@@ -121,8 +122,9 @@ This is how you do it
         func=func,                  # Function to be queued
         args=[arg1, arg2],          # Arguments passed into function when executed
         kwargs={'foo': 'bar'},      # Keyword arguments passed into function when executed
-        repeat=10                   # Repeat this number of times (None means repeat forever)
-        queue_name=queue_name       # In which queue the job should be put in
+        repeat=10,                  # Repeat this number of times (None means repeat forever)
+        queue_name=queue_name,      # In which queue the job should be put in
+        meta={'foo': 'bar'}         # Arbitrary pickleable data on the job itself
     )
 
 -------------------------

--- a/rq_scheduler/scheduler.py
+++ b/rq_scheduler/scheduler.py
@@ -109,7 +109,7 @@ class Scheduler(object):
 
     def _create_job(self, func, args=None, kwargs=None, commit=True,
                     result_ttl=None, ttl=None, id=None, description=None,
-                    queue_name=None, timeout=None):
+                    queue_name=None, timeout=None, meta=None):
         """
         Creates an RQ job and saves it to Redis.
         """
@@ -120,7 +120,7 @@ class Scheduler(object):
         job = self.job_class.create(
                 func, args=args, connection=self.connection,
                 kwargs=kwargs, result_ttl=result_ttl, ttl=ttl, id=id,
-                description=description, timeout=timeout)
+                description=description, timeout=timeout, meta=meta)
         if self._queue is not None:
             job.origin = self._queue.name
         else:
@@ -159,10 +159,11 @@ class Scheduler(object):
         job_ttl = kwargs.pop('job_ttl', None)
         job_result_ttl = kwargs.pop('job_result_ttl', None)
         job_description = kwargs.pop('job_description', None)
+        meta = kwargs.pop('meta', None)
 
         job = self._create_job(func, args=args, kwargs=kwargs, timeout=timeout,
                                id=job_id, result_ttl=job_result_ttl, ttl=job_ttl,
-                               description=job_description)
+                               description=job_description, meta=meta)
         self.connection._zadd(self.scheduled_jobs_key,
                               to_unix(scheduled_time),
                               job.id)
@@ -179,10 +180,11 @@ class Scheduler(object):
         job_ttl = kwargs.pop('job_ttl', None)
         job_result_ttl = kwargs.pop('job_result_ttl', None)
         job_description = kwargs.pop('job_description', None)
+        meta = kwargs.pop('meta', None)
 
         job = self._create_job(func, args=args, kwargs=kwargs, timeout=timeout,
                                id=job_id, result_ttl=job_result_ttl, ttl=job_ttl,
-                               description=job_description)
+                               description=job_description, meta=meta)
         self.connection._zadd(self.scheduled_jobs_key,
                               to_unix(datetime.utcnow() + time_delta),
                               job.id)
@@ -190,7 +192,8 @@ class Scheduler(object):
 
     def schedule(self, scheduled_time, func, args=None, kwargs=None,
                  interval=None, repeat=None, result_ttl=None, ttl=None,
-                 timeout=None, id=None, description=None, queue_name=None):
+                 timeout=None, id=None, description=None, queue_name=None,
+                 meta=None):
         """
         Schedule a job to be periodically executed, at a certain interval.
         """
@@ -200,7 +203,7 @@ class Scheduler(object):
         job = self._create_job(func, args=args, kwargs=kwargs, commit=False,
                                result_ttl=result_ttl, ttl=ttl, id=id,
                                description=description, queue_name=queue_name,
-                               timeout=timeout)
+                               timeout=timeout, meta=meta)
 
         if interval is not None:
             job.meta['interval'] = int(interval)
@@ -215,7 +218,7 @@ class Scheduler(object):
         return job
 
     def cron(self, cron_string, func, args=None, kwargs=None, repeat=None,
-             queue_name=None, id=None, timeout=None, description=None):
+             queue_name=None, id=None, timeout=None, description=None, meta=None):
         """
         Schedule a cronjob
         """
@@ -225,7 +228,7 @@ class Scheduler(object):
         # Otherwise the job would expire after 500 sec.
         job = self._create_job(func, args=args, kwargs=kwargs, commit=False,
                                result_ttl=-1, id=id, queue_name=queue_name,
-                               description=description, timeout=timeout)
+                               description=description, timeout=timeout, meta=meta)
 
         job.meta['cron_string'] = cron_string
 


### PR DESCRIPTION
Allow arbitrary pickleable data to be attached to a job created by the scheduler.

> To add/update custom status information on this job, you have access to the meta property, which allows you to store arbitrary pickleable data on the job itself ~ http://python-rq.org/docs/jobs/

Addresses Issue #187 