### PR TITLE
Add optional argument to use local timezone for cron-scheduled jobs (redux)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *.pyc
+venv
+*.egg-info

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+dist: trusty
 
 python:
   - "2.7"

--- a/README.rst
+++ b/README.rst
@@ -131,7 +131,8 @@ This is how you do it
         kwargs={'foo': 'bar'},      # Keyword arguments passed into function when executed
         repeat=10,                  # Repeat this number of times (None means repeat forever)
         queue_name=queue_name,      # In which queue the job should be put in
-        meta={'foo': 'bar'}         # Arbitrary pickleable data on the job itself
+        meta={'foo': 'bar'},        # Arbitrary pickleable data on the job itself
+        use_local_timezone=False    # Interpret hours in the local timezone
     )
 
 -------------------------
@@ -236,7 +237,7 @@ Running the Scheduler as a Service on Ubuntu
 sudo /etc/systemd/system/rqscheduler.service
 
 .. code-block:: bash
-    
+
     [Unit]
     Description=RQScheduler
     After=network.target
@@ -248,7 +249,7 @@ sudo /etc/systemd/system/rqscheduler.service
     [Install]
     WantedBy=multi-user.target
 
-You will also want to add any command line parameters if your configuration is not localhost or not set in the environmnt variabes.  
+You will also want to add any command line parameters if your configuration is not localhost or not set in the environmnt variabes.
 
 Start, check Status and Enable the service
 

--- a/rq_scheduler/utils.py
+++ b/rq_scheduler/utils.py
@@ -1,8 +1,7 @@
 import calendar
 import croniter
 
-from datetime import datetime, timedelta
-from dateutil.tz import tzlocal, gettz
+from datetime import datetime, timedelta, timezone
 import logging
 
 from rq.utils import ColorizingStreamHandler
@@ -23,9 +22,9 @@ def to_unix(dt):
 def get_next_scheduled_time(cron_string, use_local_timezone=False):
     """Calculate the next scheduled time by creating a crontab object
     with a cron string"""
-    now = datetime.now(tzlocal()) if use_local_timezone else datetime.utcnow()
+    now = datetime.now() if use_local_timezone else datetime.utcnow()
     itr = croniter.croniter(cron_string, now)
-    return itr.get_next(datetime).astimezone(gettz("UTC")) if use_local_timezone else itr.get_next(datetime)
+    return itr.get_next(datetime).astimezone(timezone.utc) if use_local_timezone else itr.get_next(datetime)
 
 
 def setup_loghandlers(level='INFO'):

--- a/rq_scheduler/utils.py
+++ b/rq_scheduler/utils.py
@@ -1,7 +1,8 @@
 import calendar
 import croniter
 
-from datetime import datetime, timedelta, timezone
+import datetime
+from datetime import datetime, timedelta, tzinfo
 import logging
 
 from rq.utils import ColorizingStreamHandler
@@ -22,9 +23,9 @@ def to_unix(dt):
 def get_next_scheduled_time(cron_string, use_local_timezone=False):
     """Calculate the next scheduled time by creating a crontab object
     with a cron string"""
-    now = datetime.now(timezone.utc) if use_local_timezone else datetime.utcnow()
+    now = datetime.now(get_utc_timezone()) if use_local_timezone else datetime.utcnow()
     itr = croniter.croniter(cron_string, now)
-    return itr.get_next(datetime).astimezone(timezone.utc) if use_local_timezone else itr.get_next(datetime)
+    return itr.get_next(datetime).astimezone(get_utc_timezone()) if use_local_timezone else itr.get_next(datetime)
 
 
 def setup_loghandlers(level='INFO'):
@@ -51,3 +52,23 @@ def rationalize_until(until=None):
     elif isinstance(until, timedelta):
         until = to_unix((datetime.utcnow() + until))
     return until
+
+
+class UTCTimezone(tzinfo):
+    def utcoffset(self, dt):
+        return timedelta(0)
+
+    def tzname(self, dt):
+        return "UTC"
+
+    def dst(self, dt):
+        return timedelta(0)
+
+
+__utc_timezone = UTCTimezone()
+
+
+def get_utc_timezone():
+    if hasattr(datetime, 'timezone'):
+        return datetime.get_utc_timezone()
+    return __utc_timezone

--- a/rq_scheduler/utils.py
+++ b/rq_scheduler/utils.py
@@ -2,6 +2,7 @@ import calendar
 import croniter
 
 from datetime import datetime, timedelta
+from dateutil.tz import tzlocal, gettz
 import logging
 
 from rq.utils import ColorizingStreamHandler
@@ -19,11 +20,12 @@ def to_unix(dt):
     return calendar.timegm(dt.utctimetuple())
 
 
-def get_next_scheduled_time(cron_string):
+def get_next_scheduled_time(cron_string, use_local_timezone=False):
     """Calculate the next scheduled time by creating a crontab object
     with a cron string"""
-    itr = croniter.croniter(cron_string, datetime.utcnow())
-    return itr.get_next(datetime)
+    now = datetime.now(tzlocal()) if use_local_timezone else datetime.utcnow()
+    itr = croniter.croniter(cron_string, now)
+    return itr.get_next(datetime).astimezone(gettz("UTC")) if use_local_timezone else itr.get_next(datetime)
 
 
 def setup_loghandlers(level='INFO'):

--- a/rq_scheduler/utils.py
+++ b/rq_scheduler/utils.py
@@ -22,7 +22,7 @@ def to_unix(dt):
 def get_next_scheduled_time(cron_string, use_local_timezone=False):
     """Calculate the next scheduled time by creating a crontab object
     with a cron string"""
-    now = datetime.now() if use_local_timezone else datetime.utcnow()
+    now = datetime.now(timezone.utc) if use_local_timezone else datetime.utcnow()
     itr = croniter.croniter(cron_string, now)
     return itr.get_next(datetime).astimezone(timezone.utc) if use_local_timezone else itr.get_next(datetime)
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 import os
 import signal
 import time
@@ -8,7 +8,7 @@ from rq import Queue
 from rq.compat import as_text
 from rq.job import Job
 from rq_scheduler import Scheduler
-from rq_scheduler.utils import to_unix, from_unix, get_next_scheduled_time
+from rq_scheduler.utils import to_unix, from_unix, get_next_scheduled_time, get_utc_timezone
 
 from tests import RQTestCase
 
@@ -452,8 +452,8 @@ class TestScheduler(RQTestCase):
         unix_time = self.testconn.zscore(self.scheduler.scheduled_jobs_key, job.id)
         datetime_time = from_unix(unix_time)
 
-        expected_datetime_in_local_tz = datetime.now(timezone.utc).replace(hour=15,minute=0,second=0,microsecond=0)
-        assert datetime_time.time() == expected_datetime_in_local_tz.astimezone(timezone.utc).time()
+        expected_datetime_in_local_tz = datetime.now(get_utc_timezone()).replace(hour=15,minute=0,second=0,microsecond=0)
+        assert datetime_time.time() == expected_datetime_in_local_tz.astimezone(get_utc_timezone()).time()
 
     def test_crontab_rescheduled_correctly_with_local_timezone(self):
         # Create a job with a cronjob_string
@@ -469,8 +469,8 @@ class TestScheduler(RQTestCase):
         unix_time = self.testconn.zscore(self.scheduler.scheduled_jobs_key, job.id)
         datetime_time = from_unix(unix_time)
 
-        expected_datetime_in_local_tz = datetime.now(timezone.utc).replace(hour=15,minute=2,second=0,microsecond=0)
-        assert datetime_time.time() == expected_datetime_in_local_tz.astimezone(timezone.utc).time()
+        expected_datetime_in_local_tz = datetime.now(get_utc_timezone()).replace(hour=15,minute=2,second=0,microsecond=0)
+        assert datetime_time.time() == expected_datetime_in_local_tz.astimezone(get_utc_timezone()).time()
 
     def test_crontab_sets_timeout(self):
         """

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -458,21 +458,20 @@ class TestScheduler(RQTestCase):
 
     def test_crontab_rescheduled_correctly_with_local_timezone(self):
         # Create a job with a cronjob_string
-        job = self.scheduler.cron("1 * * * *", say_hello, use_local_timezone=True)
+        job = self.scheduler.cron("1 15 * * *", say_hello, use_local_timezone=True)
 
         # change crontab
-        job.meta['cron_string'] = "2 * * * *"
+        job.meta['cron_string'] = "2 15 * * *"
 
-        # enqueue the job
+        # reenqueue the job
         self.scheduler.enqueue_job(job)
 
-        self.assertIn(job.id,
-            tl(self.testconn.zrange(self.scheduler.scheduled_jobs_key, 0, 1)))
+        # get the scheduled_time and convert it to a datetime object
+        unix_time = self.testconn.zscore(self.scheduler.scheduled_jobs_key, job.id)
+        datetime_time = from_unix(unix_time)
 
-        # check that new next scheduled time is set correctly
-        expected_next_scheduled_time = to_unix(get_next_scheduled_time("2 * * * *", use_local_timezone=True))
-        self.assertEqual(self.testconn.zscore(self.scheduler.scheduled_jobs_key, job.id),
-                         expected_next_scheduled_time)
+        expected_datetime_in_local_tz = datetime.now(tz=tzlocal()).replace(hour=15,minute=2,second=0,microsecond=0)
+        assert datetime_time.time() == expected_datetime_in_local_tz.astimezone(gettz("UTC")).time()
 
     def test_crontab_sets_timeout(self):
         """

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -452,7 +452,7 @@ class TestScheduler(RQTestCase):
         unix_time = self.testconn.zscore(self.scheduler.scheduled_jobs_key, job.id)
         datetime_time = from_unix(unix_time)
 
-        expected_datetime_in_local_tz = datetime.now().replace(hour=15,minute=0,second=0,microsecond=0)
+        expected_datetime_in_local_tz = datetime.now(timezone.utc).replace(hour=15,minute=0,second=0,microsecond=0)
         assert datetime_time.time() == expected_datetime_in_local_tz.astimezone(timezone.utc).time()
 
     def test_crontab_rescheduled_correctly_with_local_timezone(self):
@@ -469,7 +469,7 @@ class TestScheduler(RQTestCase):
         unix_time = self.testconn.zscore(self.scheduler.scheduled_jobs_key, job.id)
         datetime_time = from_unix(unix_time)
 
-        expected_datetime_in_local_tz = datetime.now().replace(hour=15,minute=2,second=0,microsecond=0)
+        expected_datetime_in_local_tz = datetime.now(timezone.utc).replace(hour=15,minute=2,second=0,microsecond=0)
         assert datetime_time.time() == expected_datetime_in_local_tz.astimezone(timezone.utc).time()
 
     def test_crontab_sets_timeout(self):

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,5 +1,4 @@
-from datetime import datetime, timedelta
-from dateutil.tz import gettz, tzlocal
+from datetime import datetime, timedelta, timezone
 import os
 import signal
 import time
@@ -453,8 +452,8 @@ class TestScheduler(RQTestCase):
         unix_time = self.testconn.zscore(self.scheduler.scheduled_jobs_key, job.id)
         datetime_time = from_unix(unix_time)
 
-        expected_datetime_in_local_tz = datetime.now(tz=tzlocal()).replace(hour=15,minute=0,second=0,microsecond=0)
-        assert datetime_time.time() == expected_datetime_in_local_tz.astimezone(gettz("UTC")).time()
+        expected_datetime_in_local_tz = datetime.now().replace(hour=15,minute=0,second=0,microsecond=0)
+        assert datetime_time.time() == expected_datetime_in_local_tz.astimezone(timezone.utc).time()
 
     def test_crontab_rescheduled_correctly_with_local_timezone(self):
         # Create a job with a cronjob_string
@@ -470,8 +469,8 @@ class TestScheduler(RQTestCase):
         unix_time = self.testconn.zscore(self.scheduler.scheduled_jobs_key, job.id)
         datetime_time = from_unix(unix_time)
 
-        expected_datetime_in_local_tz = datetime.now(tz=tzlocal()).replace(hour=15,minute=2,second=0,microsecond=0)
-        assert datetime_time.time() == expected_datetime_in_local_tz.astimezone(gettz("UTC")).time()
+        expected_datetime_in_local_tz = datetime.now().replace(hour=15,minute=2,second=0,microsecond=0)
+        assert datetime_time.time() == expected_datetime_in_local_tz.astimezone(timezone.utc).time()
 
     def test_crontab_sets_timeout(self):
         """


### PR DESCRIPTION
This is an improved version of #168

- Properly reschedule with local TZ on second execution
- Added docs
- Added rescheduling test
- Rebased