### PR TITLE
Feature: Multiple Schedulers

### DIFF
--- a/rq_scheduler/scheduler.py
+++ b/rq_scheduler/scheduler.py
@@ -3,6 +3,7 @@ import signal
 import time
 import os
 import socket
+from uuid import uuid4
 
 from datetime import datetime
 from itertools import repeat
@@ -28,7 +29,7 @@ class Scheduler(object):
     job_class = Job
 
     def __init__(self, queue_name='default', queue=None, interval=60, connection=None,
-                 job_class=None, queue_class=None):
+                 job_class=None, queue_class=None, name=None):
         from rq.connections import resolve_connection
         self.connection = resolve_connection(connection)
         self._queue = queue
@@ -42,19 +43,7 @@ class Scheduler(object):
         self.job_class = backend_class(self, 'job_class', override=job_class)
         self.queue_class = backend_class(self, 'queue_class',
                                          override=queue_class)
-
-    @property
-    def name(self):
-        """Returns the name of the scheduler, under which it is registered to the
-        monitoring system.
-        By default, the name of the scheduler is constructed from the current
-        (short) host name and the current PID.
-        """
-        # if self._name is None:
-        hostname = socket.gethostname()
-        shortname, _, _ = hostname.partition('.')
-        self._name = '{0}.{1}'.format(shortname, self.pid)
-        return self._name
+        self.name = name or uuid4().hex
 
     @property
     def key(self):

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -68,6 +68,48 @@ class TestScheduler(RQTestCase):
         scheduler1.remove_lock()
         self.assertNotIn(key, tl(self.testconn.keys('*')))
 
+    def test_multiple_schedulers_are_running_simultaneously(self):
+        """
+        Even though only 1 Schedulder holds the lock and performs the scheduling.
+        Multiple schedulders are still registered to take over in case the original
+        scheduler goes down.
+        """
+        lock_key = Scheduler.scheduler_lock_key
+        self.assertNotIn(lock_key, tl(self.testconn.keys('*')))
+        scheduler1 = Scheduler(connection=self.testconn, interval=20)
+        scheduler2 = Scheduler(connection=self.testconn, interval=20)
+        scheduler1.register_birth()
+        self.assertIn(scheduler1.key, tl(self.testconn.keys('*')))
+        scheduler2.register_birth()
+        self.assertIn(scheduler2.key, tl(self.testconn.keys('*')))
+        scheduler1.acquire_lock()
+        scheduler2.acquire_lock()
+        self.assertIn(scheduler1.key, tl(self.testconn.keys('*')))
+        self.assertIn(scheduler2.key, tl(self.testconn.keys('*')))
+
+    def test_lock_handover_between_multiple_schedulers(self):
+        lock_key = Scheduler.scheduler_lock_key
+        self.assertNotIn(lock_key, tl(self.testconn.keys('*')))
+        scheduler1 = Scheduler(connection=self.testconn, interval=20)
+        scheduler2 = Scheduler(connection=self.testconn, interval=20)
+        scheduler1.register_birth()
+        scheduler1.acquire_lock()
+        scheduler2.register_birth()
+        scheduler2.acquire_lock()
+        # Both schedulers are still active/registered
+        self.assertIn(scheduler1.key, tl(self.testconn.keys('*')))
+        self.assertIn(scheduler2.key, tl(self.testconn.keys('*')))
+        scheduler1.remove_lock()
+        self.assertNotIn(lock_key, tl(self.testconn.keys('*')))
+        scheduler2.acquire_lock()
+        self.assertIn(lock_key, tl(self.testconn.keys('*')))
+
+    def test_same_scheduler_cant_register_multiple_times(self):
+        scheduler1 = Scheduler(connection=self.testconn, interval=20)
+        scheduler1.register_birth()
+        self.assertIn(scheduler1.key, tl(self.testconn.keys('*')))
+        self.assertRaises(ValueError, scheduler1.register_birth)
+
     def test_create_job(self):
         """
         Ensure that jobs are created properly.

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -41,7 +41,7 @@ class TestScheduler(RQTestCase):
         interval so it automatically expires if scheduler is unexpectedly
         terminated.
         """
-        key = '%s_lock' % Scheduler.scheduler_key
+        key = Scheduler.scheduler_lock_key
         self.assertNotIn(key, tl(self.testconn.keys('*')))
         scheduler = Scheduler(connection=self.testconn, interval=20)
         self.assertTrue(scheduler.acquire_lock())
@@ -56,7 +56,7 @@ class TestScheduler(RQTestCase):
         same time. When removing the lock, only the scheduler which
         originally acquired the lock can remove the lock.
         """
-        key = '%s_lock' % Scheduler.scheduler_key
+        key = Scheduler.scheduler_lock_key
         self.assertNotIn(key, tl(self.testconn.keys('*')))
         scheduler1 = Scheduler(connection=self.testconn, interval=20)
         scheduler2 = Scheduler(connection=self.testconn, interval=20)
@@ -632,9 +632,7 @@ class TestScheduler(RQTestCase):
         """
         Test that scheduler accepts 'interval' of type float, less than 1 second.
         """
-        key = Scheduler.scheduler_key
-        lock_key = '%s_lock' % Scheduler.scheduler_key
-        self.assertNotIn(key, tl(self.testconn.keys('*')))
+        lock_key = Scheduler.scheduler_lock_key
         scheduler = Scheduler(connection=self.testconn, interval=0.1)   # testing interval = 0.1 second
         self.assertEqual(scheduler._interval, 0.1)
 


### PR DESCRIPTION
This PR is in reference to issue #195 

It adds the feature of running multiple scheduler instances (on multiple servers).

Each scheduler registers itself, then tries to acquire a lock to process the scheduling work. If the lock gets acquired it will schedule the jobs to the appropriate queues, remove the lock, and sleep for it's interval.

In the meanwhile another scheduler can try to acquire the lock. If it fails, it will simply sleep for its interval and try again later.

This way we don't have a single scheduler doing all the work. Different schedulers may acquire the lock at different time instances.

I've made sure that even those schedulers who can't acquire a lock have still registered their birth and a heartbeat makes sure the scheduler instance key doesn't expire even if the instance never acquires a lock.

Please let me know how we can proceed :)