### PR TITLE
Feature limit duplicates

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -105,6 +105,7 @@ This is how you do it
         kwargs={'foo': 'bar'},         # Keyword arguments passed into function when executed
         interval=60,                   # Time before the function is called again, in seconds
         repeat=10,                     # Repeat this number of times (None means repeat forever)
+        max_in_queue=3,                # Maximum times the job appears in the queue at a given moment
         meta={'foo': 'bar'}            # Arbitrary pickleable data on the job itself
     )
 

--- a/rq_scheduler/scheduler.py
+++ b/rq_scheduler/scheduler.py
@@ -196,7 +196,7 @@ class Scheduler(object):
     def schedule(self, scheduled_time, func, args=None, kwargs=None,
                  interval=None, repeat=None, result_ttl=None, ttl=None,
                  timeout=None, id=None, description=None, queue_name=None,
-                 meta=None):
+                 meta=None, max_in_queue=None):
         """
         Schedule a job to be periodically executed, at a certain interval.
         """
@@ -214,6 +214,8 @@ class Scheduler(object):
             job.meta['repeat'] = int(repeat)
         if repeat and interval is None:
             raise ValueError("Can't repeat a job without interval argument")
+        if max_in_queue is not None:
+            job.meta['max_in_queue'] = int(max_in_queue)
         job.save()
         self.connection.zadd(self.scheduled_jobs_key,
                               {job.id: to_unix(scheduled_time)})
@@ -321,6 +323,8 @@ class Scheduler(object):
             job_id = job_id.decode('utf-8')
             try:
                 job = self.job_class.fetch(job_id, connection=self.connection)
+                if self.is_job_reach_max_in_queue(job):
+                    continue
             except NoSuchJobError:
                 # Delete jobs that aren't there from scheduler
                 self.cancel(job_id)
@@ -347,6 +351,17 @@ class Scheduler(object):
                               job.origin)
         return self.queue_class.from_queue_key(
                 key, connection=self.connection, job_class=self.job_class)
+
+    def is_job_reach_max_in_queue(self, job):
+        """
+        Returns a boolean indicating whether the given job reach it max times
+        on it queue, by it max_in_queue field.
+        """
+        max_jobs_in_queue = job.meta.get("max_in_queue", None)
+        if max_jobs_in_queue is None:
+            return False
+        relevant_queue = self.get_queue_for_job(job)
+        return relevant_queue.job_ids.count(job.job_id) >= max_jobs_in_queue
 
     def enqueue_job(self, job):
         """

--- a/rq_scheduler/scheduler.py
+++ b/rq_scheduler/scheduler.py
@@ -361,7 +361,7 @@ class Scheduler(object):
         if max_jobs_in_queue is None:
             return False
         relevant_queue = self.get_queue_for_job(job)
-        return relevant_queue.job_ids.count(job.job_id) >= max_jobs_in_queue
+        return relevant_queue.job_ids.count(job.id) >= max_jobs_in_queue
 
     def enqueue_job(self, job):
         """

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -558,21 +558,18 @@ class TestScheduler(RQTestCase):
 
     def test_job_not_queued_more_than_max_in_queue(self):
         """
-        Ensure that jobs with interval lower than it actual run time, queued
-        not more that max_in_queue times.
+        Ensure that jobs queued not more max_in_queue times.
         """
-        def sleep_and_say_hello():
-            time.sleep(5)
-            return say_hello()
-
         time_now = datetime.utcnow()
         interval = 1
         max_in_queue = 1
-        job = self.scheduler.schedule(time_now, sleep_and_say_hello, interval=interval, max_in_queue=max_in_queue)
-        time.sleep(10)
+        scheduler_with_small_interval = Scheduler(connection=self.testconn, interval=1)
+        job = scheduler_with_small_interval.schedule(time_now, say_hello, interval=interval,
+                                                     max_in_queue=max_in_queue, queue_name="test_queue")
+        time.sleep(3)
 
-        relevant_queue = self.scheduler.get_queue_for_job(job)
-        num_of_appearances_in_queue = relevant_queue.job_ids.count(job.job_id)
+        relevant_queue = scheduler_with_small_interval.get_queue_for_job(job)
+        num_of_appearances_in_queue = relevant_queue.job_ids.count(job.id)
         self.assertLessEqual(num_of_appearances_in_queue, max_in_queue)
 
     def test_job_with_crontab_get_rescheduled(self):

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -556,6 +556,25 @@ class TestScheduler(RQTestCase):
         self.scheduler.enqueue_job(job)
         self.assertEqual(job.meta, meta)
 
+    def test_job_not_queued_more_than_max_in_queue(self):
+        """
+        Ensure that jobs with interval lower than it actual run time, queued
+        not more that max_in_queue times.
+        """
+        def sleep_and_say_hello():
+            time.sleep(5)
+            return say_hello()
+
+        time_now = datetime.utcnow()
+        interval = 1
+        max_in_queue = 1
+        job = self.scheduler.schedule(time_now, sleep_and_say_hello, interval=interval, max_in_queue=max_in_queue)
+        time.sleep(10)
+
+        relevant_queue = self.scheduler.get_queue_for_job(job)
+        num_of_appearances_in_queue = relevant_queue.job_ids.count(job.job_id)
+        self.assertLessEqual(num_of_appearances_in_queue, max_in_queue)
+
     def test_job_with_crontab_get_rescheduled(self):
         # Create a job with a cronjob_string
         job = self.scheduler.cron("1 * * * *", say_hello)


### PR DESCRIPTION
A new feature - the option to limit the quantity of a given job in it's queue.
This is useful when the job duration is sometimes greater than the interval, and then the queue is filling up.