### PR TITLE
Add function name to the debug logs

### DIFF
--- a/rq_scheduler/scheduler.py
+++ b/rq_scheduler/scheduler.py
@@ -353,7 +353,7 @@ class Scheduler(object):
         Move a scheduled job to a queue. In addition, it also does puts the job
         back into the scheduler if needed.
         """
-        self.log.debug('Pushing {0} to {1}'.format(job.id, job.origin))
+        self.log.debug('Pushing {0}({1}) to {1}'.format(job.func_name, job.id, job.origin))
 
         interval = job.meta.get('interval', None)
         repeat = job.meta.get('repeat', None)

--- a/rq_scheduler/scheduler.py
+++ b/rq_scheduler/scheduler.py
@@ -353,7 +353,7 @@ class Scheduler(object):
         Move a scheduled job to a queue. In addition, it also does puts the job
         back into the scheduler if needed.
         """
-        self.log.debug('Pushing {0}({1}) to {1}'.format(job.func_name, job.id, job.origin))
+        self.log.debug('Pushing {0}({1}) to {2}'.format(job.func_name, job.id, job.origin))
 
         interval = job.meta.get('interval', None)
         repeat = job.meta.get('repeat', None)


### PR DESCRIPTION
When debugging it is not very user friendly it just shows the job.id. This change adds the function name to help debug problems.

The current log output looks something like this:

```
Pushing fdfc4e56-22fa-474f-9378-e6dad47f5fc9 to default-medium
```

I think we can all agree that after 5 or 10 scheduled jobs this becomes pretty meaningless. I propose this:

```
Pushing path.to.func_name(fdfc4e56-22fa-474f-9378-e6dad47f5fc9) to default-medium
```