### PR TITLE
Use a transaction when enqueuing a job to ensure atomicity

### DIFF
--- a/rq_scheduler/scheduler.py
+++ b/rq_scheduler/scheduler.py
@@ -365,23 +365,45 @@ class Scheduler(object):
             job.meta['repeat'] = int(repeat) - 1
 
         queue = self.get_queue_for_job(job)
-        queue.enqueue_job(job)
-        self.connection.zrem(self.scheduled_jobs_key, job.id)
 
-        if interval:
-            # If this is a repeat job and counter has reached 0, don't repeat
-            if repeat is not None:
-                if job.meta['repeat'] == 0:
+        with self.connection.pipeline() as pipe:
+            while True:
+                try:
+                    pipe.watch(self.scheduled_jobs_key)
+                    queue.enqueue_job(job)
+                    pipe.multi()
+                    pipe.zrem(self.scheduled_jobs_key, job.id)
+
+                    if not (interval or cron_string):
+                        pipe.execute()
+                        return
+
+                    # If this is a repeat job and counter has reached 0, don't repeat
+                    if repeat is not None:
+                        if job.meta['repeat'] == 0:
+                            pipe.execute()
+                            return
+
+                    next_scheduled_time = (
+                        to_unix(datetime.utcnow()) + int(interval)
+                        if interval else
+                        to_unix(
+                            get_next_scheduled_time(
+                                cron_string,
+                                use_local_timezone=use_local_timezone
+                            )
+                        )
+                    )
+
+                    pipe.zadd(self.scheduled_jobs_key, {job.id: next_scheduled_time})
+                    pipe.execute()
                     return
-            self.connection.zadd(self.scheduled_jobs_key,
-                                  {job.id: to_unix(datetime.utcnow()) + int(interval)})
-        elif cron_string:
-            # If this is a repeat job and counter has reached 0, don't repeat
-            if repeat is not None:
-                if job.meta['repeat'] == 0:
-                    return
-            self.connection.zadd(self.scheduled_jobs_key,
-                                  {job.id: to_unix(get_next_scheduled_time(cron_string, use_local_timezone=use_local_timezone))})
+                except WatchError:
+                    self.log.info(
+                        f"{self.scheduled_jobs_key} changed between the time of "
+                        f"watching and the pipeline's execution."
+                    )
+                    continue
 
     def enqueue_jobs(self):
         """


### PR DESCRIPTION
There are cases when the scheduler receives a SIGKILL between the `zrem` and `zadd` from `enqueue_job()`. This would, in turn, lead to occasional unscheduling of the repeatable jobs. 

The solution I propose is to put everything in an atomic transaction and thus assure atomicity.