### PR TITLE
Allow chose queue type when the job is scheduled

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,6 +69,11 @@ There are two ways you can schedule a job. The first is using RQ Scheduler's ``e
     # complete with args and kwargs.
     scheduler.enqueue_at(datetime(2020, 1, 1, 3, 4), func, foo, bar=baz)
 
+    # You can choose the queue type where jobs will be enqueued by passing the name of the type to the scheduler
+    # used to enqueue
+    scheduler = Scheduler('foo', queue_class="rq.Queue")
+    scheduler.enqueue_at(datetime(2020, 1, 1), func) # The job will be enqueued at the queue named "foo" using the queue type "rq.Queue"
+
 
 The second way is using ``enqueue_in``. Instead of taking a ``datetime`` object,
 this method expects a ``timedelta`` and schedules the job to run at


### PR DESCRIPTION
By default, rq-scheduler allowed to choose the queue type when the `run` process of rq-scheduler was started. These queue type was used for all scheduled jobs. You weren't able to choose an specific queue type for each job, they used the same queue type.

This PR allows choose the queue type of each job when it is scheduler. The param `queue_class` it's stored as job metadata when the job is scheduled.

Then when de job is queued the rqscheduler checks if the job has an especific `queue_class` defined and uses it. If there is no `queue_class` in the meta data of the job then the queue_class of the main rq-scheduler is used.
