### PR TITLE
fixed local TZ handling - fixes #247

### DIFF
--- a/rq_scheduler/utils.py
+++ b/rq_scheduler/utils.py
@@ -2,7 +2,6 @@ import calendar
 import croniter
 import dateutil.tz
 
-import datetime
 from datetime import datetime, timedelta, tzinfo
 import logging
 

--- a/rq_scheduler/utils.py
+++ b/rq_scheduler/utils.py
@@ -1,5 +1,6 @@
 import calendar
 import croniter
+import dateutil.tz
 
 import datetime
 from datetime import datetime, timedelta, tzinfo
@@ -23,9 +24,10 @@ def to_unix(dt):
 def get_next_scheduled_time(cron_string, use_local_timezone=False):
     """Calculate the next scheduled time by creating a crontab object
     with a cron string"""
-    now = datetime.now(get_utc_timezone()) if use_local_timezone else datetime.utcnow()
+    tz = dateutil.tz.tzlocal() if use_local_timezone else dateutil.tz.UTC
+    now = datetime.now(tz)
     itr = croniter.croniter(cron_string, now)
-    return itr.get_next(datetime).astimezone(get_utc_timezone()) if use_local_timezone else itr.get_next(datetime)
+    return itr.get_next(datetime).astimezone(tz)
 
 
 def setup_loghandlers(level='INFO'):
@@ -52,23 +54,3 @@ def rationalize_until(until=None):
     elif isinstance(until, timedelta):
         until = to_unix((datetime.utcnow() + until))
     return until
-
-
-class UTCTimezone(tzinfo):
-    def utcoffset(self, dt):
-        return timedelta(0)
-
-    def tzname(self, dt):
-        return "UTC"
-
-    def dst(self, dt):
-        return timedelta(0)
-
-
-__utc_timezone = UTCTimezone()
-
-
-def get_utc_timezone():
-    if hasattr(datetime, 'timezone'):
-        return datetime.get_utc_timezone()
-    return __utc_timezone

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     rqscheduler = rq_scheduler.scripts.rqscheduler:main
     ''',
     package_data={'': ['README.rst']},
-    install_requires=['croniter>=0.3.9', 'rq>=0.13'],
+    install_requires=['croniter>=0.3.9', 'rq>=0.13', 'python-dateutil'],
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Console',

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+from dateutil.tz import UTC, tzlocal
 import os
 import signal
 import time
@@ -8,7 +9,7 @@ from rq import Queue
 from rq.compat import as_text
 from rq.job import Job
 from rq_scheduler import Scheduler
-from rq_scheduler.utils import to_unix, from_unix, get_next_scheduled_time, get_utc_timezone
+from rq_scheduler.utils import to_unix, from_unix, get_next_scheduled_time
 
 from tests import RQTestCase
 
@@ -150,7 +151,7 @@ class TestScheduler(RQTestCase):
         job = self.scheduler._create_job(say_hello, depends_on="dependency", args=(), kwargs={})
         job_from_queue = Job.fetch(job.id, connection=self.testconn)
         self.assertEqual(["dependency"], job_from_queue._dependency_ids)
-    
+
     def test_create_job_with_timeout(self):
         """
         Ensure that timeout is passed to RQ.
@@ -517,8 +518,8 @@ class TestScheduler(RQTestCase):
         unix_time = self.testconn.zscore(self.scheduler.scheduled_jobs_key, job.id)
         datetime_time = from_unix(unix_time)
 
-        expected_datetime_in_local_tz = datetime.now(get_utc_timezone()).replace(hour=15,minute=0,second=0,microsecond=0)
-        assert datetime_time.time() == expected_datetime_in_local_tz.astimezone(get_utc_timezone()).time()
+        expected_datetime_in_local_tz = datetime.now(tzlocal()).replace(hour=15,minute=0,second=0,microsecond=0)
+        assert datetime_time.time() == expected_datetime_in_local_tz.astimezone(UTC).time()
 
     def test_crontab_rescheduled_correctly_with_local_timezone(self):
         # Create a job with a cronjob_string
@@ -534,8 +535,8 @@ class TestScheduler(RQTestCase):
         unix_time = self.testconn.zscore(self.scheduler.scheduled_jobs_key, job.id)
         datetime_time = from_unix(unix_time)
 
-        expected_datetime_in_local_tz = datetime.now(get_utc_timezone()).replace(hour=15,minute=2,second=0,microsecond=0)
-        assert datetime_time.time() == expected_datetime_in_local_tz.astimezone(get_utc_timezone()).time()
+        expected_datetime_in_local_tz = datetime.now(tzlocal()).replace(hour=15,minute=2,second=0,microsecond=0)
+        assert datetime_time.time() == expected_datetime_in_local_tz.astimezone(UTC).time()
 
     def test_crontab_sets_timeout(self):
         """


### PR DESCRIPTION
`to_unix` ignores TZ information - force all dates returned by `get_next_scheduled_time` to be TZ-aware and in the expected TZ right away.

⚠️ this adds dependency to `python-dateutil` for local timezone detection