### PR TITLE
Add `get_job` function to retrieve a job instance by ID

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -176,6 +176,24 @@ Example
     # returns a list of tuples:
     # [(<rq.job.Job object at 0x123456789>, datetime.datetime(2012, 11, 25, 12, 30)), ...]
 
+If you want to check if a specific job has been scheduled and know its ID, you
+can use the ``get_job`` method.
+
+.. code-block:: python
+
+    job_instance = scheduler.get_job(job_id)
+
+By default, ``get_job`` returns the job instance or ``None``, if the job does
+not exist. Similar to ``get_jobs``, you can also get the scheduled execution
+time using the ``with_time`` argument.
+
+.. code-block:: python
+
+    job_and_time = scheduler.get_job(job_id, with_time=True)
+    # returns a tuple:
+    # (<rq.job.Job object at 0x123456789>, datetime.datetime(2012, 11, 25, 12, 30))
+    # or (None, None) if there is no matching job
+
 ------------------------------
 Checking if a job is scheduled
 ------------------------------

--- a/rq_scheduler/scheduler.py
+++ b/rq_scheduler/scheduler.py
@@ -333,6 +333,24 @@ class Scheduler(object):
             # Delete jobs that aren't there from scheduler
             self.cancel(job_id)
 
+    def get_job(self, item, with_time=False):
+        """
+        Returns the scheduled job instance of the given item (a job instance or
+        job ID). If no matching job is found, None is returned for the job
+        instance.
+
+        If with_time is True, a list of tuples consisting of the job instance
+        and its scheduled execution time is returned.
+        """
+        job_id = item.id if isinstance(item, self.job_class) else item
+        score = self.connection.zscore(self.scheduled_jobs_key, job_id)
+        job = None if score is None else self._get_job_from_id(job_id)
+
+        if with_time:
+            return (job, None if job is None else from_unix(score))
+        else:
+            return job
+
     def get_jobs(self, until=None, with_times=False, offset=None, length=None):
         """
         Returns a iterator of job instances that will be queued until the given

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -305,6 +305,31 @@ class TestScheduler(RQTestCase):
         self.assertEqual(self.scheduler.count(future_test_time), 1)
         self.assertEqual(self.scheduler.count(), 2)
 
+    def test_get_job(self):
+        """
+        Ensure get_job() returns the expected job.
+        """
+        now = datetime.utcnow()
+        job = self.scheduler.enqueue_at(now, say_hello)
+        self.assertEqual(job, self.scheduler.get_job(job.id))
+
+        # Truncate microseconds to mimic the behavior of from_unix in utils.py.
+        self.assertEqual(
+            (job, now - timedelta(microseconds=now.microsecond)),
+            self.scheduler.get_job(job.id, True)
+        )
+
+    def test_job_not_found(self):
+        """
+        Ensure get_job() returns None when the job is not found.
+        """
+        now = datetime.utcnow()
+        job = self.scheduler.enqueue_at(now, say_hello)
+        self.assertEqual(None, self.scheduler.get_job("wrong-key"))
+        self.assertEqual(
+            (None, None), self.scheduler.get_job("wrong-key", True)
+        )
+
     def test_get_jobs(self):
         """
         Ensure get_jobs() returns all jobs until the specified time.


### PR DESCRIPTION
Hello. Thank you for RQ Scheduler!

I have been using RQ Scheduler and have some situations where I fetch a scheduled job, primarily to find when it is scheduled to be queued for execution by RQ. I have been using `Scheduler.get_jobs` and then looking through the results to see if the job I'm interested in is present. Of course, the cost of doing that scales with the number of jobs that are scheduled. I have a dashboard where the cost of doing this has become noticeable.

I am interested in having a fast operation to look for the job of interest, but I did not find an existing function to do this in RQ Scheduler. If I missed it, please point me to it. If not, this PR is an attempt at implementing `get_job` to retrieve a job instance using a job ID. It uses the [`ZSCORE`](https://redis.io/commands/zscore) function to quickly retrieve the job's "schedule at" time.

If this looks like a reasonable way to introduce this, great. I'm happy to incorporate your feedback. Thanks for your time!