### PR TITLE
demote lock taken log message from warning to debug

### DIFF
--- a/rq_scheduler/scheduler.py
+++ b/rq_scheduler/scheduler.py
@@ -460,7 +460,7 @@ class Scheduler(object):
                         self.log.info('RQ scheduler done, quitting')
                         break
                 else:
-                    self.log.warning('Lock already taken - skipping run')
+                    self.log.debug('Lock already taken - skipping run')
 
                 # Time has already elapsed while enqueuing jobs, so don't wait too long.
                 seconds_elapsed_since_start = time.time() - start_time


### PR DESCRIPTION
The fact that the lock is already taken and that the run is being skipped seems to be part of the normal operation of this program. Therefore, it should not be a warning, but only a debug message.

When running multiple rq schedulers under normal conditions, it starts spewing out this warning message constantly in the logs, which is not so good. Warning level should be used for things that require human intervention, not for information like this.

Potentially, I guess it could also be `info`, but it seems to me that `debug` is most appropriate.