### PR TITLE
Added the ability to choose the serializer

### DIFF
--- a/rq_scheduler/scheduler.py
+++ b/rq_scheduler/scheduler.py
@@ -130,7 +130,7 @@ class Scheduler(object):
 
     def _create_job(self, func, args=None, kwargs=None, commit=True,
                     result_ttl=None, ttl=None, id=None, description=None,
-                    queue_name=None, timeout=None, meta=None, depends_on=None, on_success=None, on_failure=None):
+                    queue_name=None, timeout=None, meta=None, depends_on=None, on_success=None, on_failure=None, serializer=None):
         """
         Creates an RQ job and saves it to Redis. The job is assigned to the
         given queue name if not None else it is assigned to scheduler queue by
@@ -145,6 +145,7 @@ class Scheduler(object):
             kwargs=kwargs, result_ttl=result_ttl, ttl=ttl, id=id,
             description=description, timeout=timeout, meta=meta,
             depends_on=depends_on,on_success=on_success,on_failure=on_failure,
+            serializer=serializer
         )
         if queue_name:
             job.origin = queue_name
@@ -198,11 +199,12 @@ class Scheduler(object):
         queue_name = kwargs.pop('queue_name', None)
         on_success = kwargs.pop('on_success', None)
         on_failure = kwargs.pop('on_failure', None)
+        serializer = kwargs.pop('serializer', None)
 
         job = self._create_job(func, args=args, kwargs=kwargs, timeout=timeout,
                                id=job_id, result_ttl=job_result_ttl, ttl=job_ttl,
                                description=job_description, meta=meta, queue_name=queue_name, depends_on=depends_on,
-                               on_success=on_success, on_failure=on_failure)
+                               on_success=on_success, on_failure=on_failure, serializer=serializer)
         self.connection.zadd(self.scheduled_jobs_key,
                               {job.id: to_unix(scheduled_time)})
         return job
@@ -223,11 +225,12 @@ class Scheduler(object):
         queue_name = kwargs.pop('queue_name', None)
         on_success = kwargs.pop('on_success', None)
         on_failure = kwargs.pop('on_failure', None)
+        serializer = kwargs.pop('serializer', None)
 
         job = self._create_job(func, args=args, kwargs=kwargs, timeout=timeout,
                                id=job_id, result_ttl=job_result_ttl, ttl=job_ttl,
                                description=job_description, meta=meta, queue_name=queue_name,
-                               depends_on=depends_on, on_success=on_success, on_failure=on_failure)
+                               depends_on=depends_on, on_success=on_success, on_failure=on_failure, serializer=serializer)
         self.connection.zadd(self.scheduled_jobs_key,
                               {job.id: to_unix(datetime.utcnow() + time_delta)})
         return job
@@ -235,7 +238,7 @@ class Scheduler(object):
     def schedule(self, scheduled_time, func, args=None, kwargs=None,
                  interval=None, repeat=None, result_ttl=None, ttl=None,
                  timeout=None, id=None, description=None,
-                 queue_name=None, meta=None, depends_on=None, on_success=None, on_failure=None):
+                 queue_name=None, meta=None, depends_on=None, on_success=None, on_failure=None, serializer=None):
         """
         Schedule a job to be periodically executed, at a certain interval.
         """
@@ -246,7 +249,7 @@ class Scheduler(object):
                                result_ttl=result_ttl, ttl=ttl, id=id,
                                description=description, queue_name=queue_name,
                                timeout=timeout, meta=meta, depends_on=depends_on,
-                               on_success=on_success, on_failure=on_failure)
+                               on_success=on_success, on_failure=on_failure, serializer=serializer)
 
         if interval is not None:
             job.meta['interval'] = int(interval)
@@ -261,7 +264,7 @@ class Scheduler(object):
 
     def cron(self, cron_string, func, args=None, kwargs=None, repeat=None,
              queue_name=None, id=None, timeout=None, description=None, meta=None, use_local_timezone=False,
-             depends_on=None, on_success=None, on_failure=None):
+             depends_on=None, on_success=None, on_failure=None, serializer=None):
         """
         Schedule a cronjob
         """
@@ -272,7 +275,7 @@ class Scheduler(object):
         job = self._create_job(func, args=args, kwargs=kwargs, commit=False,
                                result_ttl=-1, id=id, queue_name=queue_name,
                                description=description, timeout=timeout, meta=meta, depends_on=depends_on,
-                               on_success=on_success, on_failure=on_failure)
+                               on_success=on_success, on_failure=on_failure, serializer=serializer)
 
         job.meta['cron_string'] = cron_string
         job.meta['use_local_timezone'] = use_local_timezone


### PR DESCRIPTION
RQ's `Job` object can be created with a custom serializer. 
The `_create_job()` function and its invocations have been updated to use this kwarg.