### PR TITLE
Fix custom queue instructions in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,7 +58,7 @@ There are two ways you can schedule a job. The first is using RQ Scheduler's ``e
 
     # You can also instantiate a Scheduler using an RQ Queue
     queue = Queue('bar', connection=Redis())
-    scheduler = Scheduler(queue=queue)
+    scheduler = Scheduler(queue=queue, connection=queue.connection)
 
     # Puts a job into the scheduler. The API is similar to RQ except that it
     # takes a datetime object as first argument. So for example to schedule a


### PR DESCRIPTION
When instantiating a Scheduler with a custom RQ Queue as per the README, it fails with:

    rq.connections.NoRedisConnectionException: Could not resolve a Redis connection

This change adds the explicit `connection` attribute required to use a custom queue.

fixes #228