### PR TITLE
Avoid using removed rq.compat from rq older than rq 1.13

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     rqscheduler = rq_scheduler.scripts.rqscheduler:main
     ''',
     package_data={'': ['README.rst']},
-    install_requires=['crontab>=0.23.0', 'rq>=0.13', 'python-dateutil', 'freezegun'],
+    install_requires=['crontab>=0.23.0', 'rq>=1.13', 'python-dateutil', 'freezegun'],
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Console',

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -17,7 +17,6 @@ from multiprocessing import Process
 from redis import Redis
 from rq import Connection, get_current_job, get_current_connection, Queue
 from rq.decorators import job
-from rq.compat import text_type
 from rq.worker import HerokuWorker, Worker
 
 
@@ -39,7 +38,7 @@ async def say_hello_async(name=None):
 
 def say_hello_unicode(name=None):
     """A job with a single argument and a return value."""
-    return text_type(say_hello(name))  # noqa
+    return str(say_hello(name))  # noqa
 
 
 def do_nothing():

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -10,7 +10,6 @@ import freezegun
 from dateutil.tz import tzlocal
 from dateutil.tz import UTC
 from rq import Queue
-from rq.compat import as_text
 from rq.job import Job
 
 from rq_scheduler import Scheduler
@@ -28,7 +27,7 @@ def say_hello(name=None):
 
 
 def tl(l):
-    return [as_text(i) for i in l]
+    return [str(i) for i in l]
 
 
 def simple_addition(x, y, z):


### PR DESCRIPTION
rq 1.13 dropped rq.compat completed. It was replaced with a simple __str__() instead. Bump minimum version to 1.13 which provides that new api.