### PR TITLE
Fix `resolve_connection` deprecation #304

### DIFF
--- a/rq_scheduler/scheduler.py
+++ b/rq_scheduler/scheduler.py
@@ -30,8 +30,10 @@ class Scheduler(object):
 
     def __init__(self, queue_name='default', queue=None, interval=60, connection=None,
                  job_class=None, queue_class=None, name=None):
-        from rq.connections import resolve_connection
-        self.connection = resolve_connection(connection)
+        self.connection = connection
+        if self.connection is None:
+            from rq.connections import resolve_connection
+            self.connection = resolve_connection(connection)
         self._queue = queue
         if self._queue is None:
             self.queue_name = queue_name


### PR DESCRIPTION
The Connection context manager in rq is deprecated. When a connection is explicitly passed to the Scheduler avoid using the manager and triggering a warning.

Fixes #304 