### PR TITLE
Add RRule support

### DIFF
--- a/rq_scheduler/scheduler.py
+++ b/rq_scheduler/scheduler.py
@@ -306,6 +306,8 @@ class Scheduler(object):
         Schedule a recurring job via RRule
         """
         scheduled_time = get_next_rrule_scheduled_time(rrule_string)
+        if not scheduled_time:
+            return None
 
         job = self._create_job(func, args=args, kwargs=kwargs, commit=False,
                                result_ttl=result_ttl, ttl=ttl, id=id, queue_name=queue_name,

--- a/rq_scheduler/utils.py
+++ b/rq_scheduler/utils.py
@@ -37,12 +37,20 @@ def get_next_rrule_scheduled_time(rrule_string):
     with a rrule string"""
     timezone = dateutil.tz.UTC
     ruleset = dateutil.rrule.rrulestr(rrule_string, forceset=True)
-    if ruleset[0].tzinfo is None:
-        now = datetime.now()  # naive datetime
+    any_occurence = None
+    for occur in ruleset:
+        any_occurence = occur
+        break
+    if any_occurence is None:
+        return None
+    if any_occurence.tzinfo is None:
+        now = datetime.now()
     else:
-        now = datetime.now(tz=timezone)  # aware datetime
-    next_time = ruleset.after(now)
-    return next_time.astimezone(timezone)
+        now = datetime.now(tz=timezone)
+    next_occurence = ruleset.after(now)
+    if next_occurence is None:
+        return None
+    return next_occurence.astimezone(timezone)
 
 
 def setup_loghandlers(level='INFO'):


### PR DESCRIPTION
Allow to schedule jobs via [RRules](https://dateutil.readthedocs.io/en/stable/rrule.html) 