### PR TITLE
note important information about intervals

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -117,6 +117,8 @@ This is how you do it
 either do not set a `result_ttl` value or you set a value larger than the interval.
 Otherwise, the entry with the job details will expire and the job will not get re-scheduled.
 
+**IMPORTANT NOTE**: Read more about intervals in the section `Scheduler polling interval vs job interval`_ below.
+
 ------------------------
 Cron Jobs
 ------------------------
@@ -237,6 +239,43 @@ The script accepts these arguments:
 
 The arguments pull default values from environment variables with the
 same names but with a prefix of ``RQ_REDIS_``.
+
+**IMPORTANT NOTE**: Read more about intervals in the section `Scheduler polling interval vs job interval`_ below.
+
+------------------------------------------
+Scheduler polling interval vs job interval
+------------------------------------------
+
+There are two different intervals to consider when running the scheduler:
+
+* the scheduler *polling* interval
+* the job interval
+
+This code illustrates the difference:
+
+.. code-block:: python
+
+    from rq_scheduler import Scheduler
+
+    POLLING_INTERVAL = int(...)
+    JOB_INTERVAL = int(...)
+
+    # this interval defaults to 60 seconds
+    scheduler = Scheduler(interval=POLLING_INTERVAL)
+
+    scheduler.schedule(
+        scheduled_time=datetime.now(),
+        func=my_func,
+        interval=JOB_INTERVAL,
+    )
+
+    scheduler.run()
+
+
+The intervals have to satisfy the following conditions:
+
+* the job interval has to be a multiple of the scheduler interval
+* the job interval has to be greater than the scheduler interval
 
 Running the Scheduler as a Service on Ubuntu
 --------------------------------------------


### PR DESCRIPTION
As per @mojeto https://github.com/rq/rq-scheduler/issues/163#issuecomment-323629165

I feel that this would clear up some issues around rq-scheduler usage, where folks would set a < 1 minute job interval, but it still running once a minute, and being confusing. Possible also issues with seeming "drift"?

Perhaps a maintainer can give good reasons for the following directives, then I can amend the doc:

> * the job interval has to be a multiple of the scheduler interval
> * the job interval has to be greater than the scheduler interval