### PR TITLE
fix: add `default_utc=True` to `cron.next()`

### DIFF
--- a/rq_scheduler/utils.py
+++ b/rq_scheduler/utils.py
@@ -25,7 +25,7 @@ def get_next_scheduled_time(cron_string, use_local_timezone=False):
     with a cron string"""
     now = datetime.now()
     cron = crontab.CronTab(cron_string)
-    next_time = cron.next(now=now, return_datetime=True)
+    next_time = cron.next(now=now, return_datetime=True, default_utc=True)
     tz = dateutil.tz.tzlocal() if use_local_timezone else dateutil.tz.UTC
     return next_time.astimezone(tz)
 


### PR DESCRIPTION
# Fix crontab FutureWarning for UTC behavior change
Update crontab usage to explicitly specify UTC behavior to resolve deprecation warnings and ensure consistent timezone handling.
## What changed:

Added `default_utc=True` parameter to `cron.next()` calls in rq_scheduler usage
This explicitly opts into the new UTC-aware behavior that will become default in crontab 0.22.0+

### Why:

crontab library is changing default behavior from local time to UTC in version 0.22.0+
Current usage generates FutureWarning about this breaking change
Explicitly specifying `default_utc=True` ensures consistent UTC behavior across versions
Aligns with best practices for scheduler operations which should use UTC

### Testing:

Verified scheduled jobs continue to execute at correct times
Confirmed no regression in cron scheduling functionality
UTC timing behavior remains consistent

### Note:
This change explicitly adopts the new UTC-first behavior that crontab will make default, ensuring our scheduler operations remain predictable across library updates.